### PR TITLE
fix(parser): allow zero TTL in generic parser

### DIFF
--- a/packages/dnsweeper/src/core/parsers/generic.ts
+++ b/packages/dnsweeper/src/core/parsers/generic.ts
@@ -20,7 +20,7 @@ export function normalizeGeneric(row: Record<string, unknown>): CsvRecord {
   if (content) rec.content = type === 'TXT' ? content.replace(/^\"|\"$/g, '') : content;
   if (ttlRaw !== undefined && ttlRaw !== null && String(ttlRaw).trim() !== '') {
     const ttl = Number.parseInt(String(ttlRaw), 10);
-    if (Number.isFinite(ttl) && ttl > 0) rec.ttl = ttl;
+    if (Number.isFinite(ttl) && ttl >= 0) rec.ttl = ttl;
     else throw new Error('invalid ttl');
   }
   // Basic validation: certain types require content

--- a/packages/dnsweeper/tests/unit/parser-generic.test.ts
+++ b/packages/dnsweeper/tests/unit/parser-generic.test.ts
@@ -7,5 +7,11 @@ describe('normalizeGeneric', () => {
     const rec = normalizeGeneric(row);
     expect(rec).toEqual({ name: 'db.example.com', type: 'A', content: '192.0.2.1', ttl: 300 });
   });
+
+  it('allows ttl of zero', () => {
+    const row = { name: 'cache.example.com', type: 'A', content: '198.51.100.1', ttl: '0' };
+    const rec = normalizeGeneric(row);
+    expect(rec).toEqual({ name: 'cache.example.com', type: 'A', content: '198.51.100.1', ttl: 0 });
+  });
 });
 


### PR DESCRIPTION
## Summary
- permit TTL value of `0` in generic CSV parser
- test TTL zero case

## Testing
- `pnpm test`
- `pnpm lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed54ae2c8332ace8288583ba2625