### PR TITLE
feat: add analyze progress and burst options

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -62,14 +62,14 @@ npm start -- ruleset weights --set R-003=10 R-005=20
 ## Minimal config example (dnsweeper.config.json)
 ```json
 {
-  "analyze": { "qps": 200, "concurrency": 40, "timeoutMs": 3000, "dohEndpoint": "https://dns.google/resolve" },
+  "analyze": { "qps": 200, "qpsBurst": 20, "concurrency": 40, "timeoutMs": 3000, "progressIntervalMs": 1000, "dohEndpoint": "https://dns.google/resolve" },
   "risk": { "rules": { "disabled": [], "weights": { "R-003": 10 } } }
 }
 ```
 
 ## Notes (safety / limits)
 - By default, HTTP probing to private/special targets is skipped (`--allow-private` to override)
-- Control load with `qps`/`concurrency`/`timeout`
+- Control load with `qps`/`qpsBurst`/`concurrency`/`timeout`
 - Results depend on network conditions; record your measurement settings (timeout/retry/qps) in docs
 
 ## Links / Support / License

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ npm start -- ruleset weights --set R-003=10 R-005=20
 ## 設定の最小例（dnsweeper.config.json）
 ```json
 {
-  "analyze": { "qps": 200, "concurrency": 40, "timeoutMs": 3000, "dohEndpoint": "https://dns.google/resolve" },
+  "analyze": { "qps": 200, "qpsBurst": 20, "concurrency": 40, "timeoutMs": 3000, "progressIntervalMs": 1000, "dohEndpoint": "https://dns.google/resolve" },
   "risk": { "rules": { "disabled": [], "weights": { "R-003": 10 } } }
 }
 ```
 
 ## 注意（安全/制限）
 - デフォルトでプライベートIP/特殊ドメインへのHTTPプローブはスキップ（`--allow-private`で解除）
-- 負荷制御のため `qps`/`concurrency`/`timeout` を設定可能
+- 負荷制御のため `qps`/`qpsBurst`/`concurrency`/`timeout` を設定可能
 - ネットワーク状況に依存するため、計測条件（timeout/retry/qps）はdocsに明記
 
 ## リンク / サポート / ライセンス

--- a/packages/dnsweeper/src/core/config/schema.ts
+++ b/packages/dnsweeper/src/core/config/schema.ts
@@ -23,6 +23,8 @@ export const ConfigSchema = z.object({
       qps: z.number().int().nonnegative().optional(),
       concurrency: z.number().int().positive().optional(),
       timeoutMs: z.number().int().positive().optional(),
+      progressIntervalMs: z.number().int().positive().optional(),
+      qpsBurst: z.number().int().nonnegative().optional(),
       dohEndpoint: z.string().optional(),
     })
     .optional(),


### PR DESCRIPTION
## Summary
- support `progressIntervalMs` and `qpsBurst` in analyze config schema
- document progress interval and burst QPS options in README examples

## Testing
- `npm test` *(fails: sh: 1: vitest: Permission denied)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68a3eecb5b6483329172501b87035aa1