### PR TITLE
fix: remove BOM from list command

### DIFF
--- a/packages/dnsweeper/src/cli/commands/list.ts
+++ b/packages/dnsweeper/src/cli/commands/list.ts
@@ -1,4 +1,4 @@
-﻿import { Command } from 'commander';
+import { Command } from 'commander';
 import fs from 'node:fs';
 import Table from 'cli-table3';
 


### PR DESCRIPTION
## Summary
- remove Byte Order Mark from packages/dnsweeper/src/cli/commands/list.ts so it starts directly with the import statement

## Testing
- `pnpm test` *(fails: vitest: Permission denied)*
- `pnpm lint` *(fails: eslint reports errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eec897708332a1faeaf7ade4b54e