### PR TITLE
fix: make list sorting ascending by default

### DIFF
--- a/packages/dnsweeper/src/cli/commands/list.ts
+++ b/packages/dnsweeper/src/cli/commands/list.ts
@@ -44,7 +44,7 @@ export function registerListCommand(program: Command) {
       // sorting
       const key = String(opts.sort || 'risk');
       records = records.sort((a, b) => {
-        if (key === 'risk') return riskToRank((b as any).risk) - riskToRank((a as any).risk);
+        if (key === 'risk') return riskToRank((a as any).risk) - riskToRank((b as any).risk);
         const da = String((a as any).domain || '');
         const db = String((b as any).domain || '');
         return da.localeCompare(db);

--- a/packages/dnsweeper/tests/unit/list.test.ts
+++ b/packages/dnsweeper/tests/unit/list.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { registerListCommand } from '../../src/cli/commands/list.js';
+
+function writeTmpJson(data: any[]): string {
+  const dir = path.join(process.cwd(), '.tmp', 'unit');
+  fs.mkdirSync(dir, { recursive: true });
+  const f = path.join(dir, `in-${Date.now()}.json`);
+  fs.writeFileSync(f, JSON.stringify(data), 'utf8');
+  return f;
+}
+
+async function runList(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const program = new Command();
+  registerListCommand(program);
+  let out = '';
+  let err = '';
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: any[]) => {
+    out += a.join(' ') + '\n';
+  };
+  console.error = (...a: any[]) => {
+    err += a.join(' ') + '\n';
+  };
+  try {
+    await program.parseAsync(['list', ...args], { from: 'user' });
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+  return { stdout: out, stderr: err };
+}
+
+describe('list command sorting', () => {
+  it('sorts by risk ascending by default', async () => {
+    const json = writeTmpJson([
+      { domain: 'a.test', risk: 'high' },
+      { domain: 'b.test', risk: 'low' },
+      { domain: 'c.test', risk: 'medium' },
+    ]);
+    const { stdout } = await runList([json, '--format', 'json']);
+    const arr = JSON.parse(stdout);
+    expect(arr.map((r: any) => r.risk)).toEqual(['low', 'medium', 'high']);
+  });
+
+  it('sorts by risk descending with --desc', async () => {
+    const json = writeTmpJson([
+      { domain: 'a.test', risk: 'high' },
+      { domain: 'b.test', risk: 'low' },
+      { domain: 'c.test', risk: 'medium' },
+    ]);
+    const { stdout } = await runList([json, '--format', 'json', '--desc']);
+    const arr = JSON.parse(stdout);
+    expect(arr.map((r: any) => r.risk)).toEqual(['high', 'medium', 'low']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- default `list` sort by risk ascending
- test `list` ordering for ascending and `--desc`

## Testing
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a3eeca3d908332944c9da197c112a7