### PR TITLE
refactor: replace any casts with typed interfaces

### DIFF
--- a/packages/dnsweeper/src/cli/commands/annotate.ts
+++ b/packages/dnsweeper/src/cli/commands/annotate.ts
@@ -1,6 +1,14 @@
 import { Command } from 'commander';
 import fs from 'node:fs';
 
+interface AnnotatedRecord {
+  domain?: string;
+  note?: string;
+  labels?: string[];
+  marks?: Record<string, string>;
+  [key: string]: unknown;
+}
+
 type AnnotateOptions = {
   output?: string;
   contains?: string;
@@ -11,8 +19,8 @@ type AnnotateOptions = {
   pretty?: boolean;
 };
 
-function matchDomain(rec: Record<string, unknown>, contains?: string, regex?: RegExp): boolean {
-  const domain = String((rec as any).domain ?? '');
+function matchDomain(rec: AnnotatedRecord, contains?: string, regex?: RegExp): boolean {
+  const domain = String(rec.domain ?? '');
   if (!domain) return false;
   if (contains && domain.includes(contains)) return true;
   if (regex && regex.test(domain)) return true;
@@ -55,19 +63,19 @@ export function registerAnnotateCommand(program: Command) {
         }
         let matched = 0;
 
-        const out = (data as Record<string, unknown>[]).map((r) => {
+        const out = (data as AnnotatedRecord[]).map((r) => {
           if (matchDomain(r, opts.contains, re)) {
             matched += 1;
-            const next: Record<string, unknown> = { ...r };
+            const next: AnnotatedRecord = { ...r };
             if (opts.note) {
-              const prev = String((next as any).note ?? '').trim();
+              const prev = String(next.note ?? '').trim();
               next.note = prev ? `${prev}; ${opts.note}` : opts.note;
             }
             if (labels.length) {
-              next.labels = addLabels((next as any).labels, labels);
+              next.labels = addLabels(next.labels, labels);
             }
             if (Object.keys(marks).length) {
-              const prev = (next as any).marks || {};
+              const prev = next.marks || {};
               next.marks = { ...prev, ...marks };
             }
             return next;

--- a/packages/dnsweeper/src/cli/commands/import.ts
+++ b/packages/dnsweeper/src/cli/commands/import.ts
@@ -39,7 +39,7 @@ export function registerImportCommand(program: Command) {
         const papaStream = Papa.parse(Papa.NODE_STREAM_INPUT, {
           header: true,
           skipEmptyLines: true,
-        }) as unknown as NodeJS.ReadWriteStream;
+        });
 
         papaStream.on('data', (row: unknown) => {
           const r = row as Record<string, unknown>;
@@ -57,7 +57,7 @@ export function registerImportCommand(program: Command) {
         const cfg = await loadConfig().catch(() => null);
         const provider: Provider = opts.provider || detectProviderFromHeader(headerCaptured || []);
         // Header validation
-        const headers = headerCaptured || [];
+        const headers: string[] = headerCaptured || [];
         const headerCheck = validateHeaders(provider, headers);
         if (!headerCheck.ok) {
           // Push all rows to errors with reason and abort normalization to avoid misleading output
@@ -71,8 +71,8 @@ export function registerImportCommand(program: Command) {
         }
         // Unknown headers warning (not required/optional)
         try {
-          const { HEADER_SPECS } = await import('../../core/parsers/spec.js');
-          const spec: any = (HEADER_SPECS as any)[provider];
+          const { HEADER_SPECS } = await import('../../core/parsers/spec.js') as typeof import('../../core/parsers/spec.js');
+          const spec = HEADER_SPECS[provider];
           const allowed = new Set<string>([...spec.required, ...spec.optional, ...Object.keys(spec.aliases || {})]);
           const unknown = headers
             .map((h) => h.toLowerCase().trim())

--- a/packages/dnsweeper/src/cli/commands/list.ts
+++ b/packages/dnsweeper/src/cli/commands/list.ts
@@ -1,6 +1,7 @@
-﻿import { Command } from 'commander';
+import { Command } from 'commander';
 import fs from 'node:fs';
 import Table from 'cli-table3';
+import type { AnalyzeResult } from '../types.js';
 
 function colorRisk(risk: string): string {
   if (risk === 'high') return `\x1b[31m${risk}\x1b[0m`;
@@ -29,115 +30,137 @@ export function registerListCommand(program: Command) {
     .option('--show-candidates', 'include SRV/derived candidates summary (table/csv) and field (json)', false)
     .option('--verbose', 'print distribution summary to stderr', false)
     .description('List records by minimum risk with optional sorting and output formats')
-    .action(async (input: string, opts: { minRisk: Risk; sort?: string; desc?: boolean; format?: string; output?: string; showTls?: boolean; showEvidence?: boolean; showCandidates?: boolean }) => {
-      const raw = await fs.promises.readFile(input, 'utf8');
-      const data = JSON.parse(raw);
-      if (!Array.isArray(data)) {
-        throw new Error('input JSON must be an array');
-      }
-      const minRisk = (opts.minRisk || 'low') as Risk;
-      const minRank = riskToRank(minRisk);
-      let records = (data as Record<string, unknown>[]) 
-        .filter((r) => ['low', 'medium', 'high'].includes(String((r as any).risk)))
-        .filter((r) => riskToRank((r as any).risk as Risk) >= minRank);
-
-      // sorting
-      const key = String(opts.sort || 'risk');
-      records = records.sort((a, b) => {
-        if (key === 'risk') return riskToRank((b as any).risk) - riskToRank((a as any).risk);
-        const da = String((a as any).domain || '');
-        const db = String((b as any).domain || '');
-        return da.localeCompare(db);
-      });
-      if (opts.desc) records.reverse();
-
-      const rows = records.map((r) => {
-        const tlsObj = (r as any).https?.tls || null;
-        const tlsStr = tlsObj ? `${tlsObj.alpn ?? ''}${tlsObj.issuer ? '/' + tlsObj.issuer : ''}` : '';
-        const evidences = Array.isArray((r as any).evidences) ? (r as any).evidences : [];
-        const rules = evidences.map((e: any) => e.ruleId).join(',');
-        const riskScore = (r as any).riskScore;
-        const candidates: string[] = Array.isArray((r as any).candidates) ? (r as any).candidates : [];
-        const candStr = candidates.length > 0 ? `${candidates[0]}${candidates.length > 1 ? ` (+${candidates.length - 1})` : ''}` : '';
-        return {
-          domain: String((r as any).domain ?? ''),
-          risk: String((r as any).risk ?? ''),
-          https: (r as any).https?.status ?? '',
-          http: (r as any).http?.status ?? '',
-          dns: (r as any).dns?.status ?? '',
-          skipped: (r as any).skipped ? 'yes' : '',
-          action: (r as any).action ?? '',
-          reason: (r as any).reason ?? '',
-          confidence: typeof (r as any).confidence === 'number' ? (r as any).confidence : '',
-          ...(opts.showTls ? { tls: opts.format === 'json' ? tlsObj : tlsStr } : {}),
-          ...(opts.showEvidence ? { riskScore: riskScore ?? '', rules: opts.format === 'json' ? evidences.map((e: any) => e.ruleId) : rules } : {}),
-          ...(opts.showCandidates ? { candidates: opts.format === 'json' ? candidates : candStr } : {}),
-        };
-      });
-
-      const fmt = String(opts.format || 'table').toLowerCase();
-      if (opts.verbose) {
-        const dist = rows.reduce(
-          (acc, r) => { (acc as any)[String((r as any).risk)] += 1; return acc; },
-          { low: 0, medium: 0, high: 0 } as Record<string, number>
-        );
-        // eslint-disable-next-line no-console
-        console.error(`[dist] low=${dist.low} medium=${dist.medium} high=${dist.high}`);
-      }
-      if (fmt === 'json') {
-        const json = JSON.stringify(rows, null, 2);
-        if (opts.output) {
-          await fs.promises.writeFile(opts.output, json, 'utf8');
-          console.log(`wrote json: ${opts.output}`);
-        } else {
-          console.log(json);
+    .action(
+      async (
+        input: string,
+        opts: {
+          minRisk: Risk;
+          sort?: string;
+          desc?: boolean;
+          format?: string;
+          output?: string;
+          showTls?: boolean;
+          showEvidence?: boolean;
+          showCandidates?: boolean;
+          verbose?: boolean;
         }
-        console.error(`count=${rows.length}`);
-        return;
-      }
-      if (fmt === 'csv') {
-        const { default: Papa } = await import('papaparse');
-        const csv = (Papa as any).unparse(rows, { header: true });
-        if (opts.output) {
-          await fs.promises.writeFile(opts.output, csv, 'utf8');
-          console.log(`wrote csv: ${opts.output}`);
-        } else {
-          process.stdout.write(csv + '\n');
+      ) => {
+        const raw = await fs.promises.readFile(input, 'utf8');
+        const data = JSON.parse(raw);
+        if (!Array.isArray(data)) {
+          throw new Error('input JSON must be an array');
         }
-        console.error(`count=${rows.length}`);
-        return;
-      }
+        const minRisk = (opts.minRisk || 'low') as Risk;
+        const minRank = riskToRank(minRisk);
+        let records = (data as AnalyzeResult[])
+          .filter((r) => r.risk && ['low', 'medium', 'high'].includes(String(r.risk)))
+          .filter((r) => riskToRank(r.risk as Risk) >= minRank);
 
-      const head = ['domain', 'risk', 'https', 'http', 'dns', 'skipped', 'action', 'reason', 'conf'] as string[];
-      if (opts.showTls) head.splice(5, 0, 'tls');
-      if (opts.showEvidence) head.push('score', 'rules');
-      if (opts.showCandidates) head.push('candidates');
-      const table = new Table({ head });
-      for (const row of rows) {
-        const line: any[] = [
-          row.domain,
-          colorRisk(row.risk),
-          String(row.https),
-          String(row.http),
-          String(row.dns),
-        ];
-        if (opts.showTls) line.push(String((row as any).tls ?? ''));
-        line.push(
-          row.skipped,
-          String(row.action || ''),
-          String(row.reason || ''),
-          String(row.confidence ?? ''),
-        );
-        if (opts.showEvidence) {
-          line.push(String((row as any).riskScore ?? ''));
-          line.push(String((row as any).rules ?? ''));
+        // sorting
+        const key = String(opts.sort || 'risk');
+        records = records.sort((a, b) => {
+          if (key === 'risk') return riskToRank(b.risk as Risk) - riskToRank(a.risk as Risk);
+          const da = String(a.domain || '');
+          const db = String(b.domain || '');
+          return da.localeCompare(db);
+        });
+        if (opts.desc) records.reverse();
+
+        const rows = records.map((r) => {
+          const tlsObj = r.https?.tls || null;
+          const tlsStr = tlsObj ? `${tlsObj.alpn ?? ''}${tlsObj.issuer ? '/' + tlsObj.issuer : ''}` : '';
+          const evidences = Array.isArray(r.evidences) ? r.evidences : [];
+          const rules = evidences.map((e) => e.ruleId).join(',');
+          const riskScore = r.riskScore;
+          const candidates: string[] = Array.isArray(r.candidates) ? r.candidates : [];
+          const candStr =
+            candidates.length > 0 ? `${candidates[0]}${candidates.length > 1 ? ` (+${candidates.length - 1})` : ''}` : '';
+          return {
+            domain: String(r.domain ?? ''),
+            risk: String(r.risk ?? ''),
+            https: r.https?.status ?? '',
+            http: r.http?.status ?? '',
+            dns: r.dns?.status ?? '',
+            skipped: r.skipped ? 'yes' : '',
+            action: r.action ?? '',
+            reason: r.reason ?? '',
+            confidence: typeof r.confidence === 'number' ? r.confidence : '',
+            ...(opts.showTls ? { tls: opts.format === 'json' ? tlsObj : tlsStr } : {}),
+            ...(opts.showEvidence
+              ? { riskScore: riskScore ?? '', rules: opts.format === 'json' ? evidences.map((e) => e.ruleId) : rules }
+              : {}),
+            ...(opts.showCandidates ? { candidates: opts.format === 'json' ? candidates : candStr } : {}),
+          };
+        });
+
+        const fmt = String(opts.format || 'table').toLowerCase();
+        if (opts.verbose) {
+          const dist = rows.reduce<Record<string, number>>(
+            (acc, r) => {
+              acc[String(r.risk)] += 1;
+              return acc;
+            },
+            { low: 0, medium: 0, high: 0 }
+          );
+          // eslint-disable-next-line no-console
+          console.error(`[dist] low=${dist.low} medium=${dist.medium} high=${dist.high}`);
         }
-        if (opts.showCandidates) {
-          line.push(String((row as any).candidates ?? ''));
+        if (fmt === 'json') {
+          const json = JSON.stringify(rows, null, 2);
+          if (opts.output) {
+            await fs.promises.writeFile(opts.output, json, 'utf8');
+            console.log(`wrote json: ${opts.output}`);
+          } else {
+            console.log(json);
+          }
+          console.error(`count=${rows.length}`);
+          return;
         }
-        table.push(line);
+        if (fmt === 'csv') {
+          const { default: Papa } = await import('papaparse');
+          const csv = Papa.unparse(rows, { header: true });
+          if (opts.output) {
+            await fs.promises.writeFile(opts.output, csv, 'utf8');
+            console.log(`wrote csv: ${opts.output}`);
+          } else {
+            process.stdout.write(csv + '\n');
+          }
+          console.error(`count=${rows.length}`);
+          return;
+        }
+
+        const head = ['domain', 'risk', 'https', 'http', 'dns', 'skipped', 'action', 'reason', 'conf'] as string[];
+        if (opts.showTls) head.splice(5, 0, 'tls');
+        if (opts.showEvidence) head.push('score', 'rules');
+        if (opts.showCandidates) head.push('candidates');
+        const table = new Table({ head });
+        for (const row of rows) {
+          const line: string[] = [
+            row.domain,
+            colorRisk(row.risk),
+            String(row.https),
+            String(row.http),
+            String(row.dns),
+          ];
+          if (opts.showTls) line.push(String((row as Record<string, unknown>).tls ?? ''));
+          line.push(
+            row.skipped,
+            String(row.action || ''),
+            String(row.reason || ''),
+            String(row.confidence ?? '')
+          );
+          if (opts.showEvidence) {
+            const rr = row as Record<string, unknown>;
+            line.push(String(rr.riskScore ?? ''));
+            line.push(String(rr.rules ?? ''));
+          }
+          if (opts.showCandidates) {
+            line.push(String((row as Record<string, unknown>).candidates ?? ''));
+          }
+          table.push(line);
+        }
+        console.log(table.toString());
+        console.log(`count=${rows.length}`);
       }
-      console.log(table.toString());
-      console.log(`count=${rows.length}`);
-    });
+    );
 }

--- a/packages/dnsweeper/src/cli/commands/ruleset.ts
+++ b/packages/dnsweeper/src/cli/commands/ruleset.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
+import type { AppConfig } from '../../core/config/schema.js';
 
 async function ensureDir(dir: string) {
   await fs.promises.mkdir(dir, { recursive: true });
@@ -81,9 +82,9 @@ export function registerRulesetCommand(program: Command) {
     .action(async (file: string) => {
       try {
         const raw = await fs.promises.readFile(file, 'utf8');
-        const { RulesetSchema } = await import('../../core/rules/engine.js');
+        const { RulesetSchema } = await import('../../core/rules/engine.js') as typeof import('../../core/rules/engine.js');
         const json = JSON.parse(raw);
-        (RulesetSchema as any).parse(json);
+        RulesetSchema.parse(json);
         // eslint-disable-next-line no-console
         console.log('OK');
       } catch (e) {
@@ -103,7 +104,7 @@ export function registerRulesetCommand(program: Command) {
     .option('--on <rules...>', 'Enable rules by ID (remove from disabled)')
     .action(async (opts: { set?: string[]; off?: string[]; on?: string[] }) => {
       const cfgPath = path.join(process.cwd(), 'dnsweeper.config.json');
-      let cfg: any = {};
+      let cfg: AppConfig = {};
       try { cfg = JSON.parse(await fs.promises.readFile(cfgPath, 'utf8')); } catch {}
       cfg.risk = cfg.risk || {};
       cfg.risk.rules = cfg.risk.rules || {};
@@ -113,8 +114,8 @@ export function registerRulesetCommand(program: Command) {
         // load known RULES for validation
         let KNOWN: Set<string> = new Set();
         try {
-          const mod = await import('../../core/risk/rules.js');
-          const RULES: Record<string, unknown> = (mod as any).RULES || {};
+          const mod = await import('../../core/risk/rules.js') as typeof import('../../core/risk/rules.js');
+          const RULES: Record<string, unknown> = mod.RULES || {};
           KNOWN = new Set(Object.keys(RULES));
         } catch {}
         for (const p of opts.set) {

--- a/packages/dnsweeper/src/cli/types.ts
+++ b/packages/dnsweeper/src/cli/types.ts
@@ -1,0 +1,25 @@
+import type { RiskLevel, RiskEvidence } from '../core/risk/types.js';
+import type { ProbeResult } from '../core/http/types.js';
+
+export interface AnalyzeResult {
+  domain: string;
+  risk?: RiskLevel;
+  https?: ProbeResult;
+  http?: ProbeResult;
+  dns?: {
+    status: string;
+    chain: Array<{ type: string; data: string; ttl?: number }>;
+    elapsedMs: number;
+    queries?: Array<{ type: string; status: string; elapsedMs: number; answers: number }>;
+  };
+  original?: Record<string, unknown>;
+  riskScore?: number;
+  evidences?: RiskEvidence[];
+  candidates?: string[];
+  skipped?: boolean;
+  skipReason?: string;
+  action?: 'keep' | 'review' | 'delete';
+  reason?: string;
+  reasonCode?: string;
+  confidence?: number;
+}

--- a/packages/dnsweeper/src/core/config/schema.ts
+++ b/packages/dnsweeper/src/core/config/schema.ts
@@ -24,6 +24,8 @@ export const ConfigSchema = z.object({
       concurrency: z.number().int().positive().optional(),
       timeoutMs: z.number().int().positive().optional(),
       dohEndpoint: z.string().optional(),
+      progressIntervalMs: z.number().int().positive().optional(),
+      qpsBurst: z.number().int().nonnegative().optional(),
     })
     .optional(),
   annotate: z

--- a/packages/dnsweeper/src/core/output/table.ts
+++ b/packages/dnsweeper/src/core/output/table.ts
@@ -16,7 +16,8 @@ export function renderTable<T extends Record<string, unknown>>(
   const table = new Table({ head, colWidths: colWidths.length ? colWidths : undefined });
   for (const r of rows) {
     const line = columns.map((c) => {
-      const v = (r as any)[c.key as string];
+      const key = c.key as keyof T;
+      const v = r[key];
       const out = c.map ? c.map(v, r) : v;
       if (out === null || out === undefined) return '';
       if (typeof out === 'object') return JSON.stringify(out);

--- a/packages/dnsweeper/src/core/output/xlsx.ts
+++ b/packages/dnsweeper/src/core/output/xlsx.ts
@@ -23,7 +23,7 @@ export async function writeXlsx(records: Record<string, unknown>[], file: string
     const wsSummary = wb.addWorksheet('Summary');
     const counts = { low: 0, medium: 0, high: 0 };
     for (const r of records) {
-      const risk = String((r as any).risk || '');
+      const risk = typeof r['risk'] === 'string' ? r['risk'] : String(r['risk'] || '');
       if (risk === 'low') counts.low += 1;
       else if (risk === 'medium') counts.medium += 1;
       else if (risk === 'high') counts.high += 1;
@@ -37,13 +37,13 @@ export async function writeXlsx(records: Record<string, unknown>[], file: string
     wsSummary.addRow({ risk: 'high', count: counts.high });
 
     // High sheet
-    const highs = records.filter((r) => String((r as any).risk) === 'high');
+    const highs = records.filter((r) => String(r['risk']) === 'high');
     const colsHigh = collectColumns(highs);
     const wsHigh = wb.addWorksheet('High');
     wsHigh.columns = colsHigh.map((k) => ({ header: k, key: k }));
     for (const r of highs) {
       const row: Record<string, unknown> = {};
-      for (const c of colsHigh) row[c] = normalizeCell((r as Record<string, unknown>)[c]);
+      for (const c of colsHigh) row[c] = normalizeCell(r[c]);
       wsHigh.addRow(row);
     }
 
@@ -53,7 +53,7 @@ export async function writeXlsx(records: Record<string, unknown>[], file: string
     wsAll.columns = colsAll.map((k) => ({ header: k, key: k }));
     for (const r of records) {
       const row: Record<string, unknown> = {};
-      for (const c of colsAll) row[c] = normalizeCell((r as Record<string, unknown>)[c]);
+      for (const c of colsAll) row[c] = normalizeCell(r[c]);
       wsAll.addRow(row);
     }
   } else {
@@ -63,7 +63,7 @@ export async function writeXlsx(records: Record<string, unknown>[], file: string
     ws.columns = columns.map((k) => ({ header: k, key: k }));
     for (const r of records) {
       const row: Record<string, unknown> = {};
-      for (const c of columns) row[c] = normalizeCell((r as Record<string, unknown>)[c]);
+      for (const c of columns) row[c] = normalizeCell(r[c]);
       ws.addRow(row);
     }
   }

--- a/packages/dnsweeper/src/core/risk/engine.ts
+++ b/packages/dnsweeper/src/core/risk/engine.ts
@@ -15,7 +15,7 @@ export function evaluateRisk(ctx: RiskContext, enabled: string[] = Object.keys(R
     const res = fn(ctx);
     if (!res) continue;
     const delta = Object.prototype.hasOwnProperty.call(overrides.weights || {}, id)
-      ? Number((overrides.weights as any)[id])
+      ? Number(overrides.weights[id])
       : res.delta;
     score += delta;
     if (res.evidence) evidences.push(res.evidence);

--- a/packages/dnsweeper/src/core/rules/engine.ts
+++ b/packages/dnsweeper/src/core/rules/engine.ts
@@ -64,7 +64,10 @@ export function applyRules(
     const checks: Array<{ contains?: string; regex?: string; risk?: RiskLevel; scoreDelta?: number }> = [];
     for (const s of rs.domainIncludes || []) checks.push({ contains: s, scoreDelta: 0.1 });
     for (const s of rs.domainRegex || []) checks.push({ regex: s, scoreDelta: 0.1 });
-    for (const r of rs.rules || []) checks.push(r.when as any as { contains?: string; regex?: string; risk?: RiskLevel; scoreDelta?: number });
+    for (const r of rs.rules || []) {
+      const { contains, regex } = r.when;
+      checks.push({ contains, regex, risk: r.risk, scoreDelta: r.scoreDelta });
+    }
     for (const c of checks) {
       if (c.contains && domain.includes(c.contains)) {
         score += c.scoreDelta ?? 0.1;

--- a/packages/dnsweeper/src/core/schema/analyze.ts
+++ b/packages/dnsweeper/src/core/schema/analyze.ts
@@ -38,12 +38,12 @@ export const AnalyzeItemSchema = z.object({
         ruleId: z.string(),
         message: z.string(),
         severity: z.enum(['low', 'medium', 'high']),
-        meta: z.record(z.unknown()).optional(),
+        meta: z.record(z.string(), z.unknown()).optional(),
       })
     )
     .optional(),
   candidates: z.array(z.string()).optional(),
-  original: z.record(z.unknown()).optional(),
+  original: z.record(z.string(), z.unknown()).optional(),
   skipped: z.boolean().optional(),
   skipReason: z.string().optional(),
 });

--- a/packages/dnsweeper/src/types/papaparse.d.ts
+++ b/packages/dnsweeper/src/types/papaparse.d.ts
@@ -8,6 +8,7 @@ declare module 'papaparse' {
   export interface PapaStatic {
     NODE_STREAM_INPUT: any;
     parse(input: any, config?: ParseConfig): NodeJS.ReadWriteStream;
+    unparse(data: unknown, config?: { header?: boolean }): string;
   }
 
   const Papa: PapaStatic;


### PR DESCRIPTION
## Summary
- introduce `AnalyzeResult` model and apply across CLI commands
- replace `any` casts with proper types for risk config, HTTP probing, and DoH resolver
- update parsing utilities and config schema to avoid `any`

## Testing
- `node node_modules/typescript/bin/tsc -p packages/dnsweeper/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a41bd1f29c8332a7aeb92c12498622