### PR TITLE
refactor: add ConfigService and inject into risk modules

### DIFF
--- a/packages/dnsweeper/src/core/config/service.ts
+++ b/packages/dnsweeper/src/core/config/service.ts
@@ -1,0 +1,18 @@
+import type { AppConfig } from './schema.js';
+import { loadConfig } from './schema.js';
+
+export class ConfigService {
+  private cfg: AppConfig | null = null;
+
+  async load(cwd = process.cwd()): Promise<AppConfig | null> {
+    if (!this.cfg) {
+      this.cfg = await loadConfig(cwd);
+    }
+    return this.cfg;
+  }
+
+  get(): AppConfig | null {
+    return this.cfg;
+  }
+}
+

--- a/packages/dnsweeper/src/core/risk/engine.ts
+++ b/packages/dnsweeper/src/core/risk/engine.ts
@@ -1,18 +1,24 @@
 import { clampScore, levelFromScore } from './weights.js';
 import { RULES } from './rules.js';
-import { getRuleOverrides } from './config.js';
+import { getRuleOverrides, getRiskThresholds } from './config.js';
 import type { RiskItem, RiskContext, RiskEvidence } from './types.js';
+import type { ConfigService } from '../config/service.js';
 
-export function evaluateRisk(ctx: RiskContext, enabled: string[] = Object.keys(RULES)): RiskItem {
+export function evaluateRisk(
+  ctx: RiskContext,
+  cfg: ConfigService,
+  enabled: string[] = Object.keys(RULES)
+): RiskItem {
   let score = 0;
   const evidences: RiskEvidence[] = [];
-  const overrides = getRuleOverrides();
+  const overrides = getRuleOverrides(cfg);
+  const th = getRiskThresholds(cfg);
   const disabled = new Set(overrides.disabled || []);
   for (const id of enabled) {
     if (disabled.has(id)) continue;
     const fn = RULES[id];
     if (!fn) continue;
-    const res = fn(ctx);
+    const res = fn(ctx, th);
     if (!res) continue;
     const delta = Object.prototype.hasOwnProperty.call(overrides.weights || {}, id)
       ? Number((overrides.weights as any)[id])

--- a/packages/dnsweeper/tests/unit/risk-engine-enabled.test.ts
+++ b/packages/dnsweeper/tests/unit/risk-engine-enabled.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateRisk } from '../../src/core/risk/engine.js';
+import { ConfigService } from '../../src/core/config/service.js';
+
+const cfgSvc = new ConfigService();
 
 describe('risk engine (enabled list)', () => {
   it('applies only selected rules', () => {
     // Name contains suspicious -> R-003 (+15) only
-    const r = evaluateRisk({ name: 'api-dev.example.com' }, ['R-003']);
+    const r = evaluateRisk({ name: 'api-dev.example.com' }, cfgSvc, ['R-003']);
     expect(r.score).toBe(15);
     expect(r.level).toBe('low');
   });
 
   it('negative + positive combine and clamp', () => {
     // proxied=true (-10) + suspicious name (+15) => 5
-    const r = evaluateRisk({ proxied: true, name: 'tmp.example' }, ['R-003', 'R-010']);
+    const r = evaluateRisk({ proxied: true, name: 'tmp.example' }, cfgSvc, ['R-003', 'R-010']);
     expect(r.score).toBe(5);
     expect(r.level).toBe('low');
   });

--- a/packages/dnsweeper/tests/unit/risk-engine.test.ts
+++ b/packages/dnsweeper/tests/unit/risk-engine.test.ts
@@ -1,44 +1,47 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateRisk } from '../../src/core/risk/engine.js';
+import { ConfigService } from '../../src/core/config/service.js';
+
+const cfgSvc = new ConfigService();
 
 describe('risk engine', () => {
   it('R-001: NXDOMAIN x3 → +40', () => {
     const ctx = { dns: { status: 'NXDOMAIN', attempts: 3 } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(40);
     expect(r.level).toBe('medium');
   });
 
   it('R-003: suspicious name → +15', () => {
     const ctx = { name: 'api-old.example.com' };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(15);
     expect(r.level).toBe('low');
   });
 
   it('R-010: proxied=true → −10', () => {
     const ctx = { proxied: true };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(0); // floor 0
   });
 
   it('R-002: DNS TIMEOUT → +10', () => {
     const ctx = { dns: { status: 'TIMEOUT' } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
     expect(r.level).toBe('low');
   });
 
   it('R-006: HTTP 5xx bumps score', () => {
     const ctx = { http: { httpsOk: false, httpOk: true, statuses: [200, 502] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
     expect(r.level).toBe('low');
   });
 
   it('R-007: HTTP 404 bumps score', () => {
     const ctx = { http: { httpsOk: true, httpOk: true, statuses: [301, 404] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
     expect(r.level).toBe('low');
   });
@@ -49,52 +52,52 @@ describe('risk engine', () => {
       name: 'tmp.example.com',
       http: { httpsOk: false, httpOk: false },
     };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(70);
     expect(r.level).toBe('high');
   });
 
   it('R-004: NXDOMAIN attempts=2 (subthreshold) → +10', () => {
     const ctx = { dns: { status: 'NXDOMAIN', attempts: 2 } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
     expect(r.level).toBe('low');
   });
 
   it('R-004: SERVFAIL attempts>=2 → +10 (with R-002 total 20)', () => {
     const ctx = { dns: { status: 'SERVFAIL', attempts: 2 } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(20);
     expect(r.level).toBe('low');
   });
 
   it('R-004: low TTL (<=30) in chain → +10', () => {
     const ctx = { dns: { status: 'NOERROR', chain: [{ type: 'A', data: '1.2.3.4', ttl: 20 }] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
   });
 
   it('R-008: CNAME without A/AAAA → +10', () => {
     const ctx = { dns: { chain: [{ type: 'CNAME', data: 'target.example.com.' }] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(10);
   });
 
   it('R-008: CNAME with terminal A present → no bump', () => {
     const ctx = { dns: { chain: [{ type: 'CNAME', data: 'target.example.com.' }, { type: 'A', data: '93.184.216.34' }] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(0);
   });
 
   it('R-009: TXT weak SPF (~all) → +5', () => {
     const ctx = { dns: { chain: [{ type: 'TXT', data: 'v=spf1 include:_spf.example.com ~all' }] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(5);
   });
 
   it('R-009: TXT strong SPF (-all) → no bump', () => {
     const ctx = { dns: { chain: [{ type: 'TXT', data: 'v=spf1 include:_spf.example.com -all' }] } };
-    const r = evaluateRisk(ctx);
+    const r = evaluateRisk(ctx, cfgSvc);
     expect(r.score).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add ConfigService to load and cache configuration
- inject ConfigService into risk engine and CLI analyze command
- update tests to pass ConfigService explicitly and drop global config

## Testing
- `npx vitest run` *(fails: sh: 1: vitest: Permission denied)*
- `pnpm lint` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a41bd2c11083329bfb2babdc85777e