### PR TITLE
refactor: make ruleset loading async

### DIFF
--- a/packages/dnsweeper/src/cli/commands/analyze.ts
+++ b/packages/dnsweeper/src/cli/commands/analyze.ts
@@ -400,7 +400,9 @@ export function registerAnalyzeCommand(program: Command) {
                   if (!options.doh || (dnsResult && dnsResult.status === 'NOERROR')) risk = 'low';
                 }
                 // Apply ruleset if provided
-                const rs = options.ruleset ? loadRuleset(options.rulesetDir || '.tmp/rulesets', options.ruleset) : null;
+                const rs = options.ruleset
+                  ? await loadRuleset(options.rulesetDir || '.tmp/rulesets', options.ruleset)
+                  : null;
                 const adjusted = rs ? applyRules(domain, risk, { ruleset: rs, dns: dnsResult }) : risk;
                 // no-downgrade: do not lower risk below base
                 if (options.noDowngrade) {

--- a/packages/dnsweeper/src/core/rules/engine.ts
+++ b/packages/dnsweeper/src/core/rules/engine.ts
@@ -24,10 +24,10 @@ export const RulesetSchema = z.object({
 
 export type Ruleset = z.infer<typeof RulesetSchema>;
 
-export function loadRuleset(dir: string, name: string): Ruleset | null {
+export async function loadRuleset(dir: string, name: string): Promise<Ruleset | null> {
   try {
     const file = path.join(dir, `${name}.json`);
-    const raw = fs.readFileSync(file, 'utf8');
+    const raw = await fs.promises.readFile(file, 'utf8');
     const json = JSON.parse(raw);
     return RulesetSchema.parse(json);
   } catch {

--- a/packages/dnsweeper/tests/unit/rules-engine.test.ts
+++ b/packages/dnsweeper/tests/unit/rules-engine.test.ts
@@ -1,21 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { applyRules, loadRuleset } from '../../src/core/rules/engine.js';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { applyRules, loadRuleset, type Ruleset } from '../../src/core/rules/engine.js';
 
 describe('rules engine', () => {
-  const rs = loadRuleset(process.cwd() + '/../../examples/rulesets', 'default');
+  let rs: Ruleset | null = null;
+  beforeAll(async () => {
+    rs = await loadRuleset(process.cwd() + '/../../examples/rulesets', 'default');
+  });
 
   it('qtypeWeights + domainIncludes can lift low -> medium', () => {
     const base = 'low' as const; // score=0.3
     const dns = { chain: [{ type: 'A', data: '93.184.216.34' }, { type: 'CNAME', data: 'cdn.other.net' }] };
     // qtype adds 0.05 + 0.05 = 0.1 → 0.4 (still low)
-    let risk = applyRules('app.example.com', base, { ruleset: rs, dns });
+    let risk = applyRules('app.example.com', base, { ruleset: rs!, dns });
     expect(risk).toBe('medium'); // includes("example") adds 0.1 → 0.5
   });
 
   it('CNAME external boost applies', () => {
     const base = 'low' as const; // 0.3
     const dns = { chain: [{ type: 'CNAME', data: 'edge.cdn.net' }] };
-    const risk = applyRules('app.example.com', base, { ruleset: rs, dns });
+    const risk = applyRules('app.example.com', base, { ruleset: rs!, dns });
     // +0.1(CNAME ext) +0.1(domainIncludes example) = 0.5 → medium
     expect(risk).toBe('medium');
   });
@@ -23,13 +26,13 @@ describe('rules engine', () => {
   it('NXDOMAIN forces high', () => {
     const base = 'low' as const;
     const dns = { status: 'NXDOMAIN', chain: [] } as any;
-    const risk = applyRules('nope.invalid', base, { ruleset: rs, dns });
+    const risk = applyRules('nope.invalid', base, { ruleset: rs!, dns });
     expect(risk).toBe('high');
   });
 
   it('rule can escalate to high with regex', () => {
     const base = 'medium' as const; // 0.6
-    const risk = applyRules('api.suspect.example.com', base, { ruleset: rs });
+    const risk = applyRules('api.suspect.example.com', base, { ruleset: rs! });
     expect(risk).toBe('high');
   });
 });


### PR DESCRIPTION
## Summary
- refactor rules engine to load rulesets using async fs.readFile
- await ruleset loading in analyze command
- adapt rules engine tests to async ruleset loading

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a41bd3f00483329fd153a303171427