### PR TITLE
feat(resolver): add configurable cache with eviction tests

### DIFF
--- a/packages/dnsweeper/src/core/resolver/cache.ts
+++ b/packages/dnsweeper/src/core/resolver/cache.ts
@@ -4,25 +4,53 @@ type CacheEntry = { result: ResolveResult; expiresAt: number };
 
 const store = new Map<string, CacheEntry>();
 
+const DEFAULT_MAX_ENTRIES = 500;
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let maxEntries = DEFAULT_MAX_ENTRIES;
+let defaultTtlMs = DEFAULT_TTL_MS;
+
 function keyOf(qname: string, qtype: string) {
   return `${qname}|${qtype}`;
+}
+
+export function configureCache(opts: { maxEntries?: number; ttlMs?: number } = {}) {
+  maxEntries = opts.maxEntries ?? (Number(process.env.DNSWEEPER_CACHE_MAX) || DEFAULT_MAX_ENTRIES);
+  defaultTtlMs = opts.ttlMs ?? (Number(process.env.DNSWEEPER_CACHE_TTL_MS) || DEFAULT_TTL_MS);
+  clearCache();
 }
 
 export function getCached(qname: string, qtype: string): ResolveResult | null {
   const k = keyOf(qname, qtype);
   const e = store.get(k);
   if (!e) return null;
-  if (Date.now() < e.expiresAt) return e.result;
+  if (Date.now() >= e.expiresAt) {
+    store.delete(k);
+    return null;
+  }
+  // refresh LRU order
   store.delete(k);
-  return null;
+  store.set(k, e);
+  return e.result;
 }
 
 export function putCached(qname: string, qtype: string, result: ResolveResult, ttlSec: number) {
-  const expiresAt = Date.now() + Math.max(0, ttlSec) * 1000;
-  store.set(keyOf(qname, qtype), { result, expiresAt });
+  const expiresAt = Date.now() + Math.min(defaultTtlMs, Math.max(0, ttlSec) * 1000);
+  const k = keyOf(qname, qtype);
+  if (store.has(k)) {
+    store.delete(k);
+  }
+  store.set(k, { result, expiresAt });
+  if (store.size > maxEntries) {
+    const oldestKey = store.keys().next().value as string | undefined;
+    if (oldestKey !== undefined) {
+      store.delete(oldestKey);
+    }
+  }
 }
 
 export function clearCache() {
   store.clear();
 }
 
+configureCache();

--- a/packages/dnsweeper/tests/unit/cache.test.ts
+++ b/packages/dnsweeper/tests/unit/cache.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { configureCache, getCached, putCached } from '../../src/core/resolver/cache.js';
+import type { ResolveResult } from '../../src/core/resolver/doh.js';
+
+function makeResult(name: string): ResolveResult {
+  return { qname: name, qtype: 'A', status: 'NOERROR', chain: [], elapsedMs: 0 };
+}
+
+describe('resolver cache eviction', () => {
+  beforeEach(() => {
+    configureCache();
+  });
+
+  it('evicts entries after ttl', async () => {
+    configureCache({ maxEntries: 10, ttlMs: 10 });
+    const r = makeResult('ttl.example.');
+    putCached(r.qname, r.qtype, r, 60);
+    expect(getCached(r.qname, r.qtype)).not.toBeNull();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(getCached('ttl.example.', 'A')).toBeNull();
+  });
+
+  it('evicts least recently used entry when max exceeded', () => {
+    configureCache({ maxEntries: 2, ttlMs: 1000 });
+    const r1 = makeResult('a.example.');
+    const r2 = makeResult('b.example.');
+    const r3 = makeResult('c.example.');
+    putCached(r1.qname, r1.qtype, r1, 60);
+    putCached(r2.qname, r2.qtype, r2, 60);
+    // access r1 to make it most recently used
+    getCached(r1.qname, r1.qtype);
+    putCached(r3.qname, r3.qtype, r3, 60);
+    expect(getCached(r1.qname, r1.qtype)).not.toBeNull();
+    expect(getCached(r2.qname, r2.qtype)).toBeNull();
+    expect(getCached(r3.qname, r3.qtype)).not.toBeNull();
+  });
+});

--- a/packages/dnsweeper/tests/unit/resolver.test.ts
+++ b/packages/dnsweeper/tests/unit/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { resolveDoh, setFetch, ResolveResult } from '../../src/core/resolver/doh.js';
-import { clearCache } from '../../src/core/resolver/cache.js';
+import { clearCache, configureCache } from '../../src/core/resolver/cache.js';
 
 type FetchLike = (input: any, init?: any) => Promise<{ status: number; json: () => Promise<any> }>;
 
@@ -10,6 +10,7 @@ function makeResponse(json: any, status = 200) {
 
 describe('resolveDoh', () => {
   beforeEach(() => {
+    configureCache();
     clearCache();
   });
 


### PR DESCRIPTION
## Summary
- replace resolver cache with configurable LRU/TTL implementation
- allow tuning cache size and TTL via `configureCache`
- add unit tests verifying TTL expiry and LRU eviction

## Testing
- `VITEST_SCOPE=unit node ../../node_modules/vitest/vitest.mjs run`


------
https://chatgpt.com/codex/tasks/task_e_68a41bd5f0308332b3a7b31decccf8ed