### PR TITLE
refactor: centralize undici fetch wrapper

### DIFF
--- a/packages/dnsweeper/src/core/http/fetch.ts
+++ b/packages/dnsweeper/src/core/http/fetch.ts
@@ -1,0 +1,8 @@
+import { fetch as undiciFetch } from 'undici';
+
+export function fetchWrapper(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  return undiciFetch(input as any, init as any) as unknown as Promise<Response>;
+}

--- a/packages/dnsweeper/src/core/http/probe.ts
+++ b/packages/dnsweeper/src/core/http/probe.ts
@@ -1,5 +1,5 @@
-import { fetch as undiciFetch } from 'undici';
 import { ProbeOptions, ProbeResult, RedirectHop, TlsInfo } from './types.js';
+import { fetchWrapper } from './fetch.js';
 import tls from 'node:tls';
 
 function classifyError(e: unknown): ProbeResult['errorType'] {
@@ -53,12 +53,12 @@ export async function probeUrl(url: string, opts: ProbeOptions = {}): Promise<Pr
 
     // Try HEAD first; fallback to GET on non-2xx or error
     const attempt = async (method: 'HEAD' | 'GET'): Promise<Response> => {
-      return (await (undiciFetch as unknown as typeof fetch)(current, {
+      return fetchWrapper(current, {
         method,
         redirect: 'manual',
         headers: userAgent ? { 'user-agent': userAgent } : undefined,
         signal: controller.signal,
-      })) as unknown as Response;
+      });
     };
 
     let res: Response | null = null;
@@ -76,12 +76,12 @@ export async function probeUrl(url: string, opts: ProbeOptions = {}): Promise<Pr
       const next = new URL(loc, current).toString();
       current = next;
       redirects += 1;
-      res = (await (undiciFetch as unknown as typeof fetch)(current, {
+      res = await fetchWrapper(current, {
         method: 'GET',
         redirect: 'manual',
         headers: userAgent ? { 'user-agent': userAgent } : undefined,
         signal: controller.signal,
-      })) as unknown as Response;
+      });
     }
 
     const elapsedMs = Date.now() - started;

--- a/packages/dnsweeper/src/core/resolver/doh.ts
+++ b/packages/dnsweeper/src/core/resolver/doh.ts
@@ -1,5 +1,5 @@
-import { fetch as undiciFetch } from 'undici';
 import { getCached, putCached } from './cache.js';
+import { fetchWrapper } from '../http/fetch.js';
 
 export type QType = 'A'|'AAAA'|'CNAME'|'TXT'|'SRV'|'CAA'|'MX'|'NS'|'PTR';
 
@@ -91,7 +91,7 @@ export async function resolveDoh(
       u.searchParams.set('type', qtype);
       u.searchParams.set('cd', cd ? '1' : '0');
 
-      const res = await (customFetch || (undiciFetch as unknown as typeof fetch))(u.toString(), {
+      const res = await (customFetch || fetchWrapper)(u.toString(), {
         method: 'GET',
         headers: { accept: 'application/dns-json' },
         signal: controller.signal,


### PR DESCRIPTION
## Summary
- add fetchWrapper to wrap undici fetch returning typed Response
- use fetchWrapper in probe and DoH resolver instead of casting

## Testing
- `node node_modules/typescript/bin/tsc packages/dnsweeper/src/core/http/fetch.ts packages/dnsweeper/src/core/http/probe.ts packages/dnsweeper/src/core/resolver/doh.ts --noEmit --lib es2022,dom --module ESNext --moduleResolution Bundler --esModuleInterop --skipLibCheck`
- `corepack pnpm -C packages/dnsweeper test` *(fails: vitest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a41bd6d3648332b19cc741fd5a244b