### PR TITLE
Validate CLI numeric options

### DIFF
--- a/packages/dnsweeper/src/cli/commands/analyze.ts
+++ b/packages/dnsweeper/src/cli/commands/analyze.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, InvalidOptionArgumentError } from 'commander';
 import fs from 'node:fs';
 import Papa from 'papaparse';
 import pLimit from 'p-limit';
@@ -68,20 +68,28 @@ async function probeDomain(domain: string, timeoutMs: number, userAgent?: string
 }
 
 export function registerAnalyzeCommand(program: Command) {
+  const intRange = (name: string, min: number, max: number) => (v: string) => {
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < min || n > max) {
+      throw new InvalidOptionArgumentError(`${name} must be an integer ${min}-${max}`);
+    }
+    return n;
+  };
+
   program
     .command('analyze')
     .argument('<input>', 'input CSV/JSON path')
     .option('--http-check', 'enable HTTP probing')
-    .option('-c, --concurrency <n>', 'max concurrent probes', (v) => parseInt(String(v), 10), 5)
-    .option('-t, --timeout <ms>', 'per-request timeout (ms)', (v) => parseInt(String(v), 10), 5000)
+    .option('-c, --concurrency <n>', 'max concurrent probes (1-1000)', intRange('concurrency', 1, 1000), 5)
+    .option('-t, --timeout <ms>', 'per-request timeout (ms, 1-60000)', intRange('timeout', 1, 60000), 5000)
     .option('--summary', 'print risk summary (with --http-check)', false)
     .option('--doh', 'enable DNS over HTTPS resolution', false)
     .option('--doh-endpoint <url>', 'DoH endpoint (default: https://dns.google/resolve)')
     .option('--dns-type <type>', 'QTYPE(s): A|AAAA|CNAME|TXT|SRV|CAA|MX|NS|PTR (comma-separated supported)', 'A')
-    .option('--dns-timeout <ms>', 'DNS timeout (ms)', (v) => parseInt(String(v), 10), 3000)
-    .option('--dns-retries <n>', 'DNS retries', (v) => parseInt(String(v), 10), 2)
+    .option('--dns-timeout <ms>', 'DNS timeout (ms, 1-60000)', intRange('dns-timeout', 1, 60000), 3000)
+    .option('--dns-retries <n>', 'DNS retries (0-10)', intRange('dns-retries', 0, 10), 2)
     .option('--allow-private', 'allow probing private/special domains or IPs', false)
-    .option('--qps <n>', 'overall queries per second limit', (v) => parseInt(String(v), 10), 0)
+    .option('--qps <n>', 'overall queries per second limit (0-10000)', intRange('qps', 0, 10000), 0)
     .option('--user-agent <ua>', 'override HTTP User-Agent header')
     .option('--ruleset <name>', 'apply ruleset from directory to adjust risk')
     .option('--ruleset-dir <dir>', 'ruleset directory', '.tmp/rulesets')

--- a/packages/dnsweeper/tests/unit/cli-invalid-options.test.ts
+++ b/packages/dnsweeper/tests/unit/cli-invalid-options.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { registerAnalyzeCommand } from '../../src/cli/commands/analyze.js';
+import { registerSweepCommand } from '../../src/cli/commands/sweep.js';
+
+describe('CLI numeric option validation', () => {
+  it('rejects invalid analyze concurrency', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAnalyzeCommand(program);
+    await expect(program.parseAsync(['analyze', '--concurrency', '0', 'input.csv'], { from: 'user' }))
+      .rejects.toHaveProperty('code', 'commander.invalidArgument');
+  });
+
+  it('rejects invalid analyze qps', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAnalyzeCommand(program);
+    await expect(program.parseAsync(['analyze', '--qps', '-1', 'input.csv'], { from: 'user' }))
+      .rejects.toHaveProperty('code', 'commander.invalidArgument');
+  });
+
+  it('rejects sweep plan min-confidence > 1', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerSweepCommand(program);
+    await expect(program.parseAsync(['sweep', 'plan', '--min-confidence', '2', 'input.json'], { from: 'user' }))
+      .rejects.toHaveProperty('code', 'commander.invalidArgument');
+  });
+
+  it('rejects sweep plan negative max-items', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerSweepCommand(program);
+    await expect(program.parseAsync(['sweep', 'plan', '--max-items', '-5', 'input.json'], { from: 'user' }))
+      .rejects.toHaveProperty('code', 'commander.invalidArgument');
+  });
+});


### PR DESCRIPTION
## Summary
- add range validation for numeric analyze options using Commander InvalidOptionArgumentError
- validate sweep plan numeric options and document acceptable ranges
- test invalid numeric CLI inputs

## Testing
- `pnpm --filter dnsweeper test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68a41bd7b37c833286ba684084de5f3d