### PR TITLE
test: add unit tests for core modules

### DIFF
--- a/packages/dnsweeper/tests/unit/probe.test.ts
+++ b/packages/dnsweeper/tests/unit/probe.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { probeUrl } from '../../src/core/http/probe.js';
+
+const fetchMock = vi.fn();
+const tlsConnectMock = vi.fn();
+
+vi.mock('undici', () => ({ fetch: fetchMock }));
+vi.mock('node:tls', () => ({
+  default: { connect: tlsConnectMock },
+  connect: tlsConnectMock,
+}));
+
+function makeRes(status: number, headers: Record<string, string> = {}) {
+  return {
+    status,
+    headers: { get: (k: string) => headers[k.toLowerCase()] },
+  } as any;
+}
+
+function mockTls() {
+  tlsConnectMock.mockImplementation((_opts: any, cb: any) => {
+    const socket: any = {
+      alpnProtocol: 'h2',
+      getPeerCertificate: () => ({ issuer: { O: 'TestCA' } }),
+      setTimeout: (_ms: number, _fn: any) => {},
+      on: (_ev: string, _fn: any) => {},
+      end: () => {},
+    };
+    cb();
+    return socket;
+  });
+}
+
+describe('probeUrl', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    tlsConnectMock.mockReset();
+  });
+
+  it('returns ok for 200', async () => {
+    mockTls();
+    fetchMock.mockResolvedValueOnce(makeRes(200));
+    const r = await probeUrl('https://example.com');
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.tls?.issuer).toBe('TestCA');
+  });
+
+  it('follows redirects', async () => {
+    mockTls();
+    fetchMock
+      .mockResolvedValueOnce(makeRes(302, { location: 'https://b.test' }))
+      .mockResolvedValueOnce(makeRes(200));
+    const r = await probeUrl('https://a.test');
+    expect(r.redirects).toBe(1);
+    expect(r.finalUrl).toBe('https://b.test');
+  });
+
+  it('falls back to GET when HEAD fails', async () => {
+    mockTls();
+    fetchMock
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(makeRes(200));
+    const r = await probeUrl('https://example.com');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(r.ok).toBe(true);
+  });
+
+  it('classifies network errors', async () => {
+    mockTls();
+    fetchMock.mockRejectedValueOnce(new Error('ENOTFOUND host'));
+    const r = await probeUrl('https://missing.test');
+    expect(r.ok).toBe(false);
+    expect(r.errorType).toBe('dns');
+  });
+
+  it('classifies http 5xx responses', async () => {
+    mockTls();
+    fetchMock.mockResolvedValueOnce(makeRes(503));
+    const r = await probeUrl('https://example.com');
+    expect(r.ok).toBe(false);
+    expect(r.errorType).toBe('http5xx');
+  });
+});

--- a/packages/dnsweeper/tests/unit/risk-config.test.ts
+++ b/packages/dnsweeper/tests/unit/risk-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/core/config/schema.js', () => ({ loadConfig: vi.fn() }));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  delete (globalThis as any).__DNSWEEPER_CFG__;
+});
+
+describe('risk config', () => {
+  it('loads config and applies overrides', async () => {
+    const { loadConfig }: any = await import('../../src/core/config/schema.js');
+    loadConfig.mockResolvedValue({
+      risk: {
+        lowTtlSec: 10,
+        servfailMinAttempts: 5,
+        nxdomainSubMin: 2,
+        nxdomainSubMax: 4,
+        rules: { weights: { 'R-001': 99 }, disabled: ['R-003'] },
+      },
+    });
+    const { warmConfig, getRiskThresholds, getRuleOverrides } = await import('../../src/core/risk/config.js');
+    await warmConfig();
+    expect(getRiskThresholds()).toEqual({ lowTtlSec: 10, servfailMinAttempts: 5, nxdomainSubMin: 2, nxdomainSubMax: 4 });
+    expect(getRuleOverrides()).toEqual({ weights: { 'R-001': 99 }, disabled: ['R-003'] });
+    const { evaluateRisk } = await import('../../src/core/risk/engine.js');
+    const r = evaluateRisk({ dns: { status: 'NXDOMAIN', attempts: 3 }, name: 'tmp.example' });
+    expect(r.score).toBe(99); // R-003 disabled, R-001 weight overridden
+  });
+
+  it('uses defaults when config load fails', async () => {
+    const { loadConfig }: any = await import('../../src/core/config/schema.js');
+    loadConfig.mockRejectedValue(new Error('fail'));
+    const { warmConfig, getRiskThresholds, getRuleOverrides } = await import('../../src/core/risk/config.js');
+    await warmConfig();
+    expect(getRiskThresholds()).toEqual({ lowTtlSec: 30, servfailMinAttempts: 2, nxdomainSubMin: 1, nxdomainSubMax: 2 });
+    expect(getRuleOverrides()).toEqual({ weights: {}, disabled: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add resolver cache expiry and SERVFAIL tests
- mock TLS and fetch to unit-test HTTP probe
- cover risk config loading with mocked filesystem

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a41bd86d848332a6451a1a3ade8e7a